### PR TITLE
DB crash when container is killed/stopped before DB is ready . (#1971)

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/Dockerfile
@@ -57,7 +57,8 @@ ENV ORACLE_BASE=/opt/oracle \
     RELINK_BINARY_FILE="relinkOracleBinary.sh" \
     SLIMMING=$SLIMMING \
     ENABLE_ARCHIVELOG=false \
-    ARCHIVELOG_DIR_NAME=archive_logs
+    ARCHIVELOG_DIR_NAME=archive_logs \
+    CHECKPOINT_FILE=".db_created"
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/runOracle.sh
@@ -148,7 +148,7 @@ export ORACLE_CHARACTERSET=${ORACLE_CHARACTERSET:-AL32UTF8}
 . "$ORACLE_BASE/$RELINK_BINARY_FILE"
 
 # Check whether database already exists
-if [ -d $ORACLE_BASE/oradata/$ORACLE_SID ]; then
+if [ -f $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE ]; then
    symLinkFiles;
    
    # Make sure audit file destination exists
@@ -167,8 +167,18 @@ else
   rm -f $ORACLE_HOME/network/admin/listener.ora
   rm -f $ORACLE_HOME/network/admin/tnsnames.ora
    
+  # Clean up incomplete database
+  rm -rf $ORACLE_BASE/oradata/$ORACLE_SID
+
   # Create database
   $ORACLE_BASE/$CREATE_DB_FILE $ORACLE_SID $ORACLE_PDB $ORACLE_PWD || exit 1;
+
+  # Check whether database is successfully created
+  $ORACLE_BASE/$CHECK_DB_FILE
+  if [ $? -eq 0 ]; then
+    # Create a checkpoint file if database is successfully created
+    touch $ORACLE_BASE/oradata/$ORACLE_SID/$CHECKPOINT_FILE
+  fi
 
   # Move database operational files to oradata
   moveFiles;

--- a/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
+++ b/OracleDatabase/SingleInstance/extensions/k8s/Dockerfile
@@ -57,4 +57,4 @@ RUN if test -e "$ORACLE_BASE/$RUN_FILE.extended"; then \
     if ! grep "$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; then \
         sed  -i "1i . $ORACLE_BASE/$RUN_FILE.$EXTENSION_NAME" "$ORACLE_BASE/$RUN_FILE"; \
     fi && \
-    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/*.py && sync
+    chmod ug+x $ORACLE_BASE/*.sh $ORACLE_BASE/scripts/extensions/setup/*.sh $ORACLE_BASE/*.py && sync


### PR DESCRIPTION
* Changed permissions of /scripts/extensions/setup/ , fixed database crash on restart of container before it is ready

* modified chmod for /scripts/extensions/setup/

* Changed timing of creating checkpoint file

* Added if condition to create checkpoint file or not

* Added comment before creating checkpoint file

* Changed comments

* Changed a comment

* Changed a comment

* Changed checkpoint file name to .db_created