### PR TITLE
Listerner Fix 19c

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/checkDBStatus.sh
@@ -48,7 +48,7 @@ EOF
    # Store return code from SQL*Plus
    ret=$?
 
-   if [ $ret -eq 0 ] && [ "$DB_ROLE" = "PRIMARY" ] && [ "`echo ${PDB_OPEN_MODE} | cut -d ' ' -f3,4`" != "READ WRITE" ]; then
+   if [ $ret -eq 0 ] && [ "$DB_ROLE" = "PRIMARY" ] && ! `echo $PDB_OPEN_MODE | grep -q "READ WRITE"`; then
       exit 2
    elif [ $ret -eq 0 ] && [ "$DB_ROLE" = "PHYSICAL STANDBY" ] && [ "$PDB_OPEN_MODE" != "READ ONLY" ]; then
       exit 2

--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -100,7 +100,9 @@ ${ORACLE_SID} =
 EOF
 
   # Re-creating listener.ora for aiding DG configuration
-  
+  # First stopping the listener
+  lsnrctl stop
+
   cat > $ORACLE_HOME/network/admin/listener.ora<<EOF
 LISTENER =
   (DESCRIPTION_LIST =
@@ -125,8 +127,8 @@ SID_LIST_LISTENER =
   )
 EOF
 
-  # Reload the listener
-  lsnrctl reload
+  # Start the listener once again
+  lsnrctl start
 
   # Enabling flashback database in Standby database
   sqlplus -s / as sysdba <<EOF


### PR DESCRIPTION
Using `lsnrctl stop` and `lsnrctl start` instead of `lsnrctl reload`. Fixes the container crash problem in k8s environment.