### PR TITLE
Fixing tnsnames overwrite issue

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-############## Setting up network related config files (sqlnet.ora, tnsnames.ora, listener.ora) ##############
+############## Setting up network related config files (sqlnet.ora, listener.ora) ##############
 function setupNetworkConfig {
   mkdir -p $ORACLE_BASE_HOME/network/admin
 


### PR DESCRIPTION
Tnsnames.ora is overwritten after dbca command execution. So, setting up tnsnames entry after the dbca command.