### PR TITLE
Adding support for database init params 21c

### DIFF
--- a/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/19.3.0/createDB.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-############## Setting up network related config files (sqlnet.ora, tnsnames.ora, listener.ora) ##############
+############## Setting up network related config files (sqlnet.ora, listener.ora) ##############
 function setupNetworkConfig {
   mkdir -p $ORACLE_HOME/network/admin
 
@@ -34,6 +34,12 @@ function setupNetworkConfig {
 DEDICATED_THROUGH_BROKER_LISTENER=ON
 DIAG_ADR_ENABLED = off
 " > $ORACLE_HOME/network/admin/listener.ora
+
+}
+
+####################### Setting up tnsnames.ora ##############################
+function setupTnsnames {
+  mkdir -p $ORACLE_HOME/network/admin
 
   # tnsnames.ora
   echo "$ORACLE_SID=localhost:1521/$ORACLE_SID" > $ORACLE_HOME/network/admin/tnsnames.ora
@@ -89,14 +95,6 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
 
   # Primary database parameters extration
   PRIMARY_DB_NAME=$(echo "${PRIMARY_DB_CONN_STR}" | cut -d '/' -f 2)
-  PRIMARY_DB_IP=$(echo "${PRIMARY_DB_CONN_STR}" | cut -d ':' -f 1)
-  PRIMARY_DB_PORT=$(echo "${PRIMARY_DB_CONN_STR}" | cut -d ':' -f 2 | cut -d '/' -f 1)
-
-  # Setup network related configuration
-  setupNetworkConfig;
-
-  # Starting Listener
-  lsnrctl start;
 
   # Creating the database using the dbca command
   if [ "${STANDBY_DB}" = "true" ]; then
@@ -110,6 +108,18 @@ if [[ "${CLONE_DB}" == "true" ]] || [[ "${STANDBY_DB}" == "true" ]]; then
       cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
       cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
   fi
+
+  # Setup tnsnames.ora after DBCA command execution, otherwise tnsnames gets overwritten by DBCA
+  setupTnsnames;
+
+  # Stopping the Listener
+  lsnrctl stop;
+
+  # Setup other network related configuration (sqlnet.ora, listener.ora)
+  setupNetworkConfig;
+
+  # Starting the Listener
+  lsnrctl start;
 
   exit 0
 fi
@@ -141,7 +151,7 @@ fi;
    sed -i "s|numberOfPDBs=1|numberOfPDBs=0|g" $ORACLE_BASE/dbca.rsp
  fi
 
-# Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
+# Create network related config files (sqlnet.ora, listener.ora)
 setupNetworkConfig;
 
 # Directory for storing archive logs
@@ -152,6 +162,9 @@ lsnrctl start &&
 dbca -silent -createDatabase -enableArchive $ENABLE_ARCHIVELOG -archiveLogDest $ARCHIVELOG_DIR -responseFile $ORACLE_BASE/dbca.rsp ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID/$ORACLE_SID.log ||
  cat /opt/oracle/cfgtoollogs/dbca/$ORACLE_SID.log
+
+# Setup tnsnames.ora after DBCA command execution, otherwise tnsnames gets overwritten by DBCA
+setupTnsnames;
 
 if [ "$CREATE_PDB" = "true" ]; then
   # Make PDB auto open

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/Dockerfile
@@ -71,7 +71,9 @@ ENV ORACLE_BASE=/opt/oracle \
     DG_OBSERVER_NAME="" \
     # if CREATE_PDB is false, default PDB is not created
     CREATE_PDB=true \
-    CHECKPOINT_FILE_EXTN=".created"
+    CHECKPOINT_FILE_EXTN=".created" \
+    # Databse Init Parameters: should be a string of format "<key1>=<value1>,<key2>=<value2> ..."
+    INIT_PARAMS=""
 
 # Use second ENV so that variable get substituted
 ENV PATH=$ORACLE_HOME/bin:$ORACLE_HOME/OPatch/:/usr/sbin:$PATH \

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -147,6 +147,12 @@ if [ "$CREATE_PDB" = "false" ]; then
   sed -i "s|numberOfPDBs=1|numberOfPDBs=0|g" $ORACLE_BASE/dbca.rsp
 fi
 
+# Adding additional Database Init Parameters
+if [[ ! -z "${INIT_PARAMS}" ]]; then
+  INIT_PARAMS=",${INIT_PARAMS}"
+fi
+sed -i -e "s|###INIT_PARAMS###|$INIT_PARAMS|g" $ORACLE_BASE/dbca.rsp
+
 # Create network related config files (sqlnet.ora, tnsnames.ora, listener.ora)
 setupNetworkConfig;
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/createDB.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-############## Setting up network related config files (sqlnet.ora, tnsnames.ora, listener.ora) ##############
+############## Setting up network related config files (sqlnet.ora, listener.ora) ##############
 function setupNetworkConfig {
   mkdir -p $ORACLE_BASE_HOME/network/admin
 

--- a/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
+++ b/OracleDatabase/SingleInstance/dockerfiles/21.3.0/dbca.rsp.tmpl
@@ -170,7 +170,7 @@ nationalCharacterSet=AL16UTF16
 # Default value : None
 # Mandatory     : NO
 #-----------------------------------------------------------------------------
-initParams=audit_trail=none,audit_sys_operations=false
+initParams=audit_trail=none,audit_sys_operations=false###INIT_PARAMS###
 
 #-----------------------------------------------------------------------------
 # Name          : listeners

--- a/OracleDatabase/SingleInstance/extensions/k8s/checkDBLockStatus.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/checkDBLockStatus.sh
@@ -20,7 +20,7 @@ elif "$ORACLE_BASE/$CHECK_DB_FILE"; then
   exit 0
 elif test -f "$ORACLE_BASE/oradata/.${ORACLE_SID}.nochk"; then
   exit 1 # Skip health check
-elif pgrep -f pmon; then
+elif pgrep -f pmon > /dev/null; then
   # DB procs detected
   exit 1
 else

--- a/OracleDatabase/SingleInstance/extensions/k8s/startDB.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/startDB.sh
@@ -27,7 +27,7 @@ for i in {1..10}; do
    startup nomount;
    exit;
 EOF
-  if pgrep -f pmon; then
+  if pgrep -f pmon > /dev/null; then
     break
   fi
   # Sometimes DB locks of dead container are not released immediately
@@ -42,7 +42,7 @@ $ORACLE_BASE/scripts/extensions/setup/$SWAP_LOCK_FILE
 lsnrctl start
 
 condn_sql=""
-if ! pgrep -f pmon; then
+if ! pgrep -f pmon > /dev/null; then
   # if Oracle processes die for some reason by the time lock is acquired
   condn_sql="shutdown abort;
   startup nomount;

--- a/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
+++ b/OracleDatabase/SingleInstance/extensions/k8s/swapLocks.sh
@@ -12,7 +12,7 @@
 #
 
 "$ORACLE_BASE/$LOCKING_SCRIPT" --release --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.create_lck"
-if ! pgrep -f "$LOCKING_SCRIPT.*--acquire.*exist_lck"; then
+if ! pgrep -f "$LOCKING_SCRIPT.*--acquire.*exist_lck" > /dev/null; then
   # Acquire exist lock if not already acquired or trying. This is a blocking call
   "$ORACLE_BASE/$LOCKING_SCRIPT" --acquire --file "$ORACLE_BASE/oradata/.${ORACLE_SID}.exist_lck" --block
 fi

--- a/OracleIdentityGovernance/dockerfiles/12.2.1.4.0/Dockerfile
+++ b/OracleIdentityGovernance/dockerfiles/12.2.1.4.0/Dockerfile
@@ -25,6 +25,7 @@ ENV FMW_JAR=fmw_12.2.1.4.0_idm_generic.jar \
     PATCH_DIR=/tmp/patches \
     OPATCH_PATCH_DIR=/tmp/opatch \
     OPATCH_NO_FUSER=true \
+    HEALTH_SCRIPT_FILE=/u01/oracle/dockertools/get_healthcheck_url.sh \
     USER_MEM_ARGS="-Djava.security.egd=file:/dev/./urandom" \
     PATH=$PATH:$JAVA_HOME/bin:$ORACLE_HOME/oracle_common/common/bin \
     DOMAIN_NAME="${DOMAIN_NAME:-base_domain}" \
@@ -44,17 +45,17 @@ RUN mkdir -p /u01 && \
     mkdir -p /u01/oracle/dockertools && \
     mkdir ${PATCH_DIR} && \
     mkdir ${OPATCH_PATCH_DIR} && \
-    chown -R oracle:oracle /u01 && \
-    chown -R oracle:oracle ${PATCH_DIR} && \
-    chown -R oracle:oracle ${OPATCH_PATCH_DIR}  
+    chown -R oracle:root /u01 && \
+    chown -R oracle:root ${PATCH_DIR} && \
+    chown -R oracle:root ${OPATCH_PATCH_DIR}  
 
 #
 # Copy files and packages for install
 # -----------------------------------
 COPY *.response oraInst.loc fmw_12.2.1.4.0_idm_generic* /u01/
 COPY container-scripts/* /u01/oracle/dockertools/
-COPY --chown=oracle:oracle Dockerfile patches/* ${PATCH_DIR}/
-COPY --chown=oracle:oracle Dockerfile opatch_patch/* ${OPATCH_PATCH_DIR}/
+COPY --chown=oracle:root Dockerfile patches/* ${PATCH_DIR}/
+COPY --chown=oracle:root Dockerfile opatch_patch/* ${OPATCH_PATCH_DIR}/
 RUN chmod a+xr /u01/oracle/dockertools/*.*
 
 USER oracle
@@ -117,7 +118,7 @@ RUN patchzips=`ls ${PATCH_DIR}/p*.zip 2>/dev/null`; \
     
 RUN rm -rf /u01/oracle/idm/server/ConnectorDefaultDirectory && \
     ln -s  /u01/oracle/user_projects/domains/ConnectorDefaultDirectory /u01/oracle/idm/server/ConnectorDefaultDirectory && \
-    if $ORACLE_HOME/OPatch/opatch lsinventory  -oh $ORACLE_HOME -jre $JAVA_HOME | grep -q 23855729; then \
+    if $ORACLE_HOME/OPatch/opatch lsinventory  -oh $ORACLE_HOME -jre $JAVA_HOME | egrep -q '23855729|24204843' ; then \
      echo "Ready End Point already Configured."; \
     else \
       sed -i 's|true</ready|false</ready|g' /u01/oracle/idm/server/apps/oim.ear/META-INF/weblogic-application.xml; \
@@ -125,9 +126,10 @@ RUN rm -rf /u01/oracle/idm/server/ConnectorDefaultDirectory && \
 
 FROM base as FINAL_BUILD
 
-COPY --from=builder --chown=oracle:oracle /u01 /u01
+COPY --from=builder --chown=oracle:root /u01 /u01
 
 USER oracle
+HEALTHCHECK --start-period=5m --interval=1m CMD curl -k -s --fail `$HEALTH_SCRIPT_FILE` || exit 1
 WORKDIR $ORACLE_HOME
 
 #

--- a/OracleIdentityGovernance/imagetool/12.2.1.4.0/README.md
+++ b/OracleIdentityGovernance/imagetool/12.2.1.4.0/README.md
@@ -118,6 +118,7 @@ For example:
 create
 --jdkVersion=8u261
 --type oig
+--chown oracle:root
 --version=12.2.1.4.0
 --tag=oig-with-patch:12.2.1.4.0
 --pull
@@ -126,6 +127,14 @@ create
 --additionalBuildFiles /scratch/docker-images/OracleIdentityGovernance/dockerfiles/12.2.1.4.0/container-scripts
 ```
 
+c) Edit the `<work_directory>/docker-images/OracleFMWInfrastructure/dockerfiles/12.2.1.4.0/install.file` and under the `GENERIC` section add the line `INSTALL_TYPE="Weblogic Server"`. For example:
+
+```
+[GENERIC]
+INSTALL_TYPE="WebLogic Server"
+DECLINE_SECURITY_UPDATES=true
+SECURITY_UPDATES_VIA_MYORACLESUPPORT=false
+```
 
 # 6. Steps to create image
 
@@ -149,18 +158,18 @@ $ imagetool cache addInstaller --type idm --version 12.2.1.4.0 --path <work dire
 ### iii) Add Patches to Imagetool cache
 
 ```
-$ imagetool cache addEntry --key 28186730_13.9.4.2.2 --path <work directory>/stage/p28186730_139422_Generic.zip
-$ imagetool cache addEntry --key 31537019_12.2.1.4.0 --path <work directory>/stage/p31537019_122140_Generic.zip
-$ imagetool cache addEntry --key 31544353_12.2.1.4.0 --path <work directory>/stage/p31544353_122140_Linux-x86-64.zip
-$ imagetool cache addEntry --key 31470730_12.2.1.4.0 --path <work directory>/stage/p31470730_122140_Generic.zip
-$ imagetool cache addEntry --key 31488215_12.2.1.4.0 --path <work directory>/stage/p31488215_122140_Generic.zip
-$ imagetool cache addEntry --key 31403376_12.2.1.4.0 --path <work directory>/stage/p31403376_122140_Generic.zip
-$ imagetool cache addEntry --key 31396632_12.2.1.4.0 --path <work directory>/stage/p31396632_122140_Generic.zip
-$ imagetool cache addEntry --key 31287540_12.2.1.4.0 --path <work directory>/stage/p31287540_122140_Generic.zip
-$ imagetool cache addEntry --key 30779352_12.2.1.4.0 --path <work directory>/stage/p30779352_122140_Generic.zip
-$ imagetool cache addEntry --key 30680769_12.2.1.4.0 --path <work directory>/stage/p30680769_122140_Generic.zip
-$ imagetool cache addEntry --key 31537918_12.2.1.4.0 --path <work directory>/stage/p31537918_122140_Generic.zip
-$ imagetool cache addEntry --key 31497461_12.2.1.4.20.06.24 --path <work directory>/stage/p31497461_12214200624_Generic.zip
+$ imagetool cache addEntry --key 28186730_13.9.4.2.2 --value <work directory>/stage/p28186730_139422_Generic.zip
+$ imagetool cache addEntry --key 31537019_12.2.1.4.0 --value <work directory>/stage/p31537019_122140_Generic.zip
+$ imagetool cache addEntry --key 31544353_12.2.1.4.0 --value <work directory>/stage/p31544353_122140_Linux-x86-64.zip
+$ imagetool cache addEntry --key 31470730_12.2.1.4.0 --value <work directory>/stage/p31470730_122140_Generic.zip
+$ imagetool cache addEntry --key 31488215_12.2.1.4.0 --value <work directory>/stage/p31488215_122140_Generic.zip
+$ imagetool cache addEntry --key 31403376_12.2.1.4.0 --value <work directory>/stage/p31403376_122140_Generic.zip
+$ imagetool cache addEntry --key 31396632_12.2.1.4.0 --value <work directory>/stage/p31396632_122140_Generic.zip
+$ imagetool cache addEntry --key 31287540_12.2.1.4.0 --value <work directory>/stage/p31287540_122140_Generic.zip
+$ imagetool cache addEntry --key 30779352_12.2.1.4.0 --value <work directory>/stage/p30779352_122140_Generic.zip
+$ imagetool cache addEntry --key 30680769_12.2.1.4.0 --value <work directory>/stage/p30680769_122140_Generic.zip
+$ imagetool cache addEntry --key 31537918_12.2.1.4.0 --value <work directory>/stage/p31537918_122140_Generic.zip
+$ imagetool cache addEntry --key 31497461_12.2.1.4.20.06.24 --value <work directory>/stage/p31497461_12214200624_Generic.zip
 ```
 
 
@@ -179,6 +188,7 @@ A sample `buildAgs` file is now as follows:
 create
 --jdkVersion=8u261
 --type oig
+--chown oracle:root
 --version=12.2.1.4.0
 --tag=oig-with-patch:12.2.1.4.0
 --pull

--- a/OracleIdentityGovernance/imagetool/12.2.1.4.0/additionalBuildCmds.txt
+++ b/OracleIdentityGovernance/imagetool/12.2.1.4.0/additionalBuildCmds.txt
@@ -1,3 +1,6 @@
+[package-manager-packages]
+hostname
+
 [final-build-commands]
 
 ENV ORACLE_HOME=/u01/oracle \
@@ -11,33 +14,32 @@ ENV ORACLE_HOME=/u01/oracle \
     OIM_PORT="${OIM_PORT:-14000}" \
     OIM_SSL_PORT="${OIM_SSL_PORT:-14002}" \
     PATH=$PATH:/u01/oracle \
-    DOMAIN_TYPE="oim"
+    DOMAIN_TYPE="oim" \
+    PATH=$PATH:/usr/java/default/bin:$ORACLE_HOME/oracle_common/common/bin:/u01/oracle/wlserver/common/bin:/u01/oracle/dockertools \
+    HEALTH_SCRIPT_FILE=/u01/oracle/dockertools/get_healthcheck_url.sh 
 
 USER root
 
-RUN yum install -y hostname && \
-    rm -rf /var/cache/yum
-
-RUN mkdir -p /u01/oracle/dockertools 
-
-RUN mkdir /usr/java
-
-RUN ln -s /u01/jdk /usr/java/latest
+RUN mkdir -p /u01/oracle/dockertools && \
+	mkdir /usr/java && \
+	ln -s /u01/jdk /usr/java/latest 
 
 RUN rm -rf /u01/oracle/idm/server/ConnectorDefaultDirectory && \
     ln -s  /u01/oracle/user_projects/domains/ConnectorDefaultDirectory /u01/oracle/idm/server/ConnectorDefaultDirectory
 
-COPY --chown=oracle:oracle files/container-scripts/ /u01/oracle/dockertools/
-RUN chmod a+xr /u01/oracle/dockertools/*.* && \
-     chown -R oracle:oracle /u01/oracle/dockertools
+COPY --chown=oracle:root files/container-scripts/ /u01/oracle/dockertools/
 
+RUN chmod a+xr /u01/oracle/dockertools/* && \
+    chown -R oracle:root /u01/oracle/dockertools
 
 USER oracle
-RUN if $ORACLE_HOME/OPatch/opatch lsinventory  -oh $ORACLE_HOME -jre $JAVA_HOME | grep -q 23855729; then \
+RUN if $ORACLE_HOME/OPatch/opatch lsinventory  -oh $ORACLE_HOME -jre $JAVA_HOME | egrep -q '23855729|24204843'; then \
      echo "Ready End Point already Configured."; \
     else \
       sed -i 's|true</ready|false</ready|g' /u01/oracle/idm/server/apps/oim.ear/META-INF/weblogic-application.xml; \
     fi
+
+HEALTHCHECK --start-period=5m --interval=1m CMD curl -k -s --fail `$HEALTH_SCRIPT_FILE` || exit 1
 
 WORKDIR $ORACLE_HOME
 CMD ["/u01/oracle/dockertools/createDomainAndStart.sh"]

--- a/OracleIdentityGovernance/imagetool/12.2.1.4.0/buildArgs
+++ b/OracleIdentityGovernance/imagetool/12.2.1.4.0/buildArgs
@@ -1,6 +1,7 @@
 create
 --jdkVersion=%JDK_VERSION%
 --type oig
+--chown oracle:root
 --version=12.2.1.4.0
 --tag=%BUILDTAG%
 --pull

--- a/OracleLinuxDevelopers/README.md
+++ b/OracleLinuxDevelopers/README.md
@@ -48,6 +48,7 @@ and Oracle Database along with the appropriate Oracle Instant Client packages.
 * [`oraclelinux7-ruby:2.6`](oraclelinux7/ruby/2.6/Dockerfile)
 * [`oraclelinux7-ruby:2.7`](oraclelinux7/ruby/2.7/Dockerfile)
 * [`oraclelinux7-ruby:2.7-nodejs`](oraclelinux7/ruby/2.7-nodejs/Dockerfile)
+* [`oraclelinux7-ruby:3.0`](oraclelinux7/ruby/3.0/Dockerfile)
 
 ## Oracle Linux 8 based images
 

--- a/OracleLinuxDevelopers/oraclelinux7/ruby/3.0/Dockerfile
+++ b/OracleLinuxDevelopers/oraclelinux7/ruby/3.0/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 Oracle and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
+FROM oraclelinux:7-slim
+
+RUN yum -y install oracle-softwarecollection-release-el7 && \
+    yum -y install rh-ruby30 \
+                   rh-ruby30-ruby-devel \
+                   rh-ruby30-rubygem-rake \
+                   rh-ruby30-rubygem-bundler \
+                   gcc make && \
+    rm -rf /var/cache/yum
+
+# Enable the SCL via environment modification
+ENV PATH=/opt/rh/rh-ruby30/root/usr/local/bin:/opt/rh/rh-ruby30/root/usr/bin${PATH:+:${PATH}} \
+    LD_LIBRARY_PATH=/opt/rh/rh-ruby30/root/usr/local/lib64:/opt/rh/rh-ruby30/root/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
+    MANPATH=/opt/rh/rh-ruby30/root/usr/local/share/man:/opt/rh/rh-ruby30/root/usr/share/man:${MANPATH} \
+    PKG_CONFIG_PATH=/opt/rh/rh-ruby30/root/usr/local/lib64/pkgconfig:/opt/rh/rh-ruby30/root/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}} \
+    XDG_DATA_DIRS=/opt/rh/rh-ruby30/root/usr/local/share:/opt/rh/rh-ruby30/root/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+
+CMD ["irb"]


### PR DESCRIPTION
Added one env variable named `INIT_PARAMS` which takes a string of the following format:
**"\<key1\><value1\>,\<key2\>=\<value2\>..."**

If this env var is passed to `docker run` command, it changes the specified init parameters of the database.